### PR TITLE
Upgrade .NET runtime

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Run dotnet format
         working-directory: ${{env.working-directory}}
         run: |
-          dotnet format --check platform-router.sln
+          dotnet format --verify-no-changes platform-router.sln

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "5.0.x"
+          dotnet-version: "6.0.x"
       - run: |
           dotnet tool install -g dotnet-format
           echo "$HOME/.dotnet/tools" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Clone source
         uses: actions/checkout@v1
 
-      - name: Install .NET SDK 5
+      - name: Install .NET SDK 6
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
 
       - name: "Build unit tests"
         run: dotnet test SensateIoT.Platform.Router.Tests/SensateIoT.Platform.Router.Tests.csproj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.7.6] - 05-12-2021
 ### Added
-- Add additional logging to the authorization router
+- Additional logging to the authorization router
 
 ### Updated
 - Project dependecies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.6] - 06-08-2021
+### Updated
+- Project dependecies
+- The .NET SDK/runtime version
+
 ## [1.7.5] - 06-08-2021
 ### Added
 - Implement the authorization router

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.7.6] - 06-08-2021
+## [1.7.6] - 05-12-2021
+### Added
+- Add additional logging to the authorization router
+
 ### Updated
 - Project dependecies
 - The .NET SDK/runtime version

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ The following metrics are collected from the routing service:
 
 [header1]: https://github.com/sensate-iot/platform-router/workflows/Docker/badge.svg "Docker Build"
 [header2]: https://github.com/sensate-iot/platform-router/workflows/Format%20check/badge.svg ".NET format"
-[header3]: https://img.shields.io/badge/version-v1.7.5-informational "Sensate IoT Router version"
+[header3]: https://img.shields.io/badge/version-v1.7.6-informational "Sensate IoT Router version"

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/AuthorizationRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/AuthorizationRouter.cs
@@ -25,8 +25,13 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 		{
 			var account = this.m_cache.GetAccount(sensor.AccountID);
 			var key = this.m_cache.GetApiKey(sensor.SensorKey);
+			var result = this.VerifySensor(sensor) && this.IsValidSensor(sensor, account, key);
 
-			return this.VerifySensor(sensor) && this.IsValidSensor(sensor, account, key);
+			if(!result) {
+				this.m_logger.LogInformation("Dropping message for sensor {sensorId}: authorization failed", sensor.ID.ToString());
+			}
+
+			return result;
 		}
 
 		private bool ValidateAccount(Sensor sensor, Account account, ApiKey key)

--- a/SensateIoT.Platform.Router.Common/SensateIoT.Platform.Router.Common.csproj
+++ b/SensateIoT.Platform.Router.Common/SensateIoT.Platform.Router.Common.csproj
@@ -17,15 +17,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="MongoDB.Bson" Version="2.13.1" />
-    <PackageReference Include="MQTTnet" Version="3.0.16" />
+    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="MongoDB.Bson" Version="2.14.1" />
+    <PackageReference Include="MQTTnet" Version="3.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="prometheus-net" Version="4.2.0" />
-    <PackageReference Include="prometheus-net.AspNetCore" Version="4.2.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.2.62" />
+    <PackageReference Include="prometheus-net" Version="5.0.2" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="5.0.2" />
+    <PackageReference Include="StackExchange.Redis" Version="2.2.88" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SensateIoT.Platform.Router.Contracts/SensateIoT.Platform.Router.Contracts.csproj
+++ b/SensateIoT.Platform.Router.Contracts/SensateIoT.Platform.Router.Contracts.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
-    <Version>1.4.0</Version>
-    <AssemblyVersion>1.4.0.0</AssemblyVersion>
-    <FileVersion>1.4.0.0</FileVersion>
+    <Version>1.4.1</Version>
+    <AssemblyVersion>1.4.1.0</AssemblyVersion>
+    <FileVersion>1.4.1.0</FileVersion>
     <Description>Message contracts for the Sensate IoT Network services.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>COPYING</PackageLicenseFile>

--- a/SensateIoT.Platform.Router.Contracts/SensateIoT.Platform.Router.Contracts.csproj
+++ b/SensateIoT.Platform.Router.Contracts/SensateIoT.Platform.Router.Contracts.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
@@ -31,10 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.17.3" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.17.2" />
-    <PackageReference Include="Grpc" Version="2.38.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.38.1">
+    <PackageReference Include="Google.Protobuf" Version="3.19.1" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.19.1" />
+    <PackageReference Include="Grpc" Version="2.42.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.42.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/SensateIoT.Platform.Router.Data/SensateIoT.Platform.Router.Data.csproj
+++ b/SensateIoT.Platform.Router.Data/SensateIoT.Platform.Router.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.0.0</Version>
     <AssemblyName>SensateIoT.Platform.Router.Data</AssemblyName>
     <RootNamespace>SensateIoT.Platform.Router.Data</RootNamespace>
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
-    <PackageReference Include="MongoDB.Bson" Version="2.13.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
+    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
+    <PackageReference Include="MongoDB.Bson" Version="2.14.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.14.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/SensateIoT.Platform.Router.DataAccess/SensateIoT.Platform.Router.DataAccess.csproj
+++ b/SensateIoT.Platform.Router.DataAccess/SensateIoT.Platform.Router.DataAccess.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
-    <PackageReference Include="Npgsql" Version="5.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.14.1" />
+    <PackageReference Include="Npgsql" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SensateIoT.Platform.Router.Service/Dockerfile
+++ b/SensateIoT.Platform.Router.Service/Dockerfile
@@ -5,7 +5,7 @@
 # @email  michel@michelmegens.net
 #
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 
 WORKDIR /build
 
@@ -13,7 +13,7 @@ COPY . .
 RUN dotnet restore -r linux-x64 SensateIoT.Platform.Router.Service/SensateIoT.Platform.Router.Service.csproj
 RUN dotnet publish -c Release -o /build/binaries -r linux-x64 --no-restore SensateIoT.Platform.Router.Service/SensateIoT.Platform.Router.Service.csproj
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 
 COPY --from=build-env /build/binaries /app
 COPY SensateIoT.Platform.Router.Service/appsettings.json /app/appsettings.json

--- a/SensateIoT.Platform.Router.Service/SensateIoT.Platform.Router.Service.csproj
+++ b/SensateIoT.Platform.Router.Service/SensateIoT.Platform.Router.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <Version>1.7.5</Version>
     <AssemblyVersion>1.7.5.0</AssemblyVersion>
@@ -14,6 +14,10 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SensateIoT.Platform.Router.Service/SensateIoT.Platform.Router.Service.csproj
+++ b/SensateIoT.Platform.Router.Service/SensateIoT.Platform.Router.Service.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
-    <Version>1.7.5</Version>
-    <AssemblyVersion>1.7.5.0</AssemblyVersion>
-    <FileVersion>1.7.5.0</FileVersion>
+    <Version>1.7.6</Version>
+    <AssemblyVersion>1.7.6.0</AssemblyVersion>
+    <FileVersion>1.7.6.0</FileVersion>
     <Copyright>Sensate IoT</Copyright>
     <Company>Sensate IoT</Company>
     <Authors>Sensate IoT</Authors>

--- a/SensateIoT.Platform.Router.Service/SensateIoT.Platform.Router.Service.csproj
+++ b/SensateIoT.Platform.Router.Service/SensateIoT.Platform.Router.Service.csproj
@@ -21,18 +21,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.17.3" />
-    <PackageReference Include="Grpc" Version="2.38.1" />
-    <PackageReference Include="Grpc.AspNetCore" Version="2.38.0" />
-    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.38.0" />
-    <PackageReference Include="prometheus-net.AspNetCore" Version="4.2.0" />
-    <PackageReference Include="prometheus-net.AspNetCore.Grpc" Version="4.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.19.1" />
+    <PackageReference Include="Grpc" Version="2.42.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.40.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.40.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="5.0.2" />
+    <PackageReference Include="prometheus-net.AspNetCore.Grpc" Version="5.0.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
-    <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+    <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SensateIoT.Platform.Router.Tests/SensateIoT.Platform.Router.Tests.csproj
+++ b/SensateIoT.Platform.Router.Tests/SensateIoT.Platform.Router.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SensateIoT.Platform.Router.Tests/SensateIoT.Platform.Router.Tests.csproj
+++ b/SensateIoT.Platform.Router.Tests/SensateIoT.Platform.Router.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Upgrade the .NET runtime version from .NET 5 to .NET 6.

## Description
The Platform Router service now targets the .NET 6 runtime, instead of .NET 5. The unit test project has also been updated in order to target this version of the .NET environment.

## Motivation and Context
Migrate away from older versions of .NET.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

