### PR TITLE
Routing improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleasaed]
 ### Added
 - Additional logging to various routers
+- Input queue processing to the composite router
 
 ### Updated
 - Project dependencies
 - Confusing log lines
 - Router metric logging
+- Control flow of the composite router
 
 ### Removed
 - Duplicate logging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleasaed]
+### Added
+- Additional logging to various routers
+
+### Updated
+- Project dependencies
+- Confusing log lines
+- Router metric logging
+
+### Removed
+- Duplicate logging
+- Code paths that cannot be executed
+
 ## [1.7.6] - 05-12-2021
 ### Added
 - Additional logging to the authorization router

--- a/SensateIoT.Platform.Router.Common/Routing/CompositeRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/CompositeRouter.cs
@@ -79,6 +79,7 @@ namespace SensateIoT.Platform.Router.Common.Routing
 					this.m_logger.LogError("Unable to complete routing {count} messages", messageList.Count);
 				}
 			} catch(AggregateException ex) {
+				this.m_logger.LogError(ex, "Unable to route {count} messages", messageList.Count);
 				throw ex.InnerException!;
 			} finally {
 				this.m_lock.ExitReadLock();
@@ -115,6 +116,7 @@ namespace SensateIoT.Platform.Router.Common.Routing
 				bool result;
 
 				try {
+					this.m_logger.LogDebug("Routing message to the {routerName}", router.Name);
 					result = router.Route(sensor, message, @event);
 				} catch(RouterException ex) {
 					result = false;
@@ -123,13 +125,22 @@ namespace SensateIoT.Platform.Router.Common.Routing
 				}
 
 				if(!result) {
-					this.m_dropCounter.Inc();
-					this.m_logger.LogDebug("Routing cancelled by the {routerName}", router.Name);
+					this.LogDroppedMessage(router, @event);
 					break;
 				}
+
+				this.m_logger.LogDebug("Routing by the {routerName} finished", router.Name);
 			}
 
+			@event.Actions.Add(NetworkEventType.MessageRouted);
 			this.m_eventQueue.EnqueueEvent(@event);
+		}
+
+		private void LogDroppedMessage(IRouter router, NetworkEvent evt)
+		{
+			this.m_dropCounter.Inc();
+			this.m_logger.LogDebug("Routing cancelled by the {routerName}", router.Name);
+			evt.Actions.Add(NetworkEventType.MessageDropped);
 		}
 
 		private static NetworkEvent CreateNetworkEvent(Sensor sensor)
@@ -139,14 +150,13 @@ namespace SensateIoT.Platform.Router.Common.Routing
 				AccountID = ByteString.CopyFrom(sensor.AccountID.ToByteArray())
 			};
 
-			evt.Actions.Add(NetworkEventType.MessageRouted);
 			return evt;
 		}
 
 		private bool VerifySensor(ObjectId sensorId, Sensor sensor)
 		{
 			if(sensor == null) {
-				this.m_logger.LogDebug("Unable to route message for sensor: {sensorId}. Sensor not found",
+				this.m_logger.LogWarning("Unable to route message for sensor: {sensorId}. Sensor not found",
 									   sensorId.ToString());
 				return false;
 			}
@@ -157,7 +167,7 @@ namespace SensateIoT.Platform.Router.Common.Routing
 			}
 
 			if(string.IsNullOrEmpty(sensor.SensorKey)) {
-				this.m_logger.LogWarning("Sensor {sensorId} has an API key", sensor.ID);
+				this.m_logger.LogWarning("Sensor {sensorId} has no API key", sensor.ID);
 				return false;
 			}
 

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/AuthorizationRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/AuthorizationRouter.cs
@@ -39,12 +39,12 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 			var invalid = false;
 
 			if(account.HasBillingLockout) {
-				this.m_logger.LogInformation("Skipping sensor {sensorId} due to billing lock", sensor.ID.ToString());
+				this.m_logger.LogInformation("Skipping sensor {sensorId} due to billing lock on account {accountId:D}", sensor.ID.ToString(), account.ID);
 				invalid = true;
 			}
 
 			if(account.IsBanned) {
-				this.m_logger.LogInformation("Skipping sensor because account {accountId:D} is banned", account.ID);
+				this.m_logger.LogInformation("Skipping sensor {sensorId} because account {accountId:D} is banned", sensor.ID.ToString(), account.ID);
 				invalid = true;
 			}
 

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/AuthorizationRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/AuthorizationRouter.cs
@@ -62,6 +62,10 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 			invalid |= key.IsReadOnly;
 			invalid |= key.IsRevoked;
 
+			if(key.IsReadOnly || key.IsRevoked) {
+				this.m_logger.LogWarning("Dropping messaage for sensor {sensorId}, sensor key is invalid", sensor.ID.ToString());
+			}
+
 			return !invalid;
 		}
 

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/BaseRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/BaseRouter.cs
@@ -6,6 +6,8 @@
  */
 
 using Microsoft.Extensions.Logging;
+
+using SensateIoT.Platform.Router.Common.Exceptions;
 using SensateIoT.Platform.Router.Common.Routing.Abstract;
 using SensateIoT.Platform.Router.Contracts.DTO;
 using SensateIoT.Platform.Router.Data.Abstract;
@@ -26,8 +28,6 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 
 		public bool Route(Sensor sensor, IPlatformMessage message, NetworkEvent networkEvent)
 		{
-			var result = true;
-
 			switch(message.Type) {
 			case MessageType.Measurement:
 				networkEvent.MessageType = NetworkMessageType.Measurement;
@@ -44,11 +44,10 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 			default:
 				this.m_logger.LogWarning("Unable to determine message type of type {type}. Integer value: {integerValue}.",
 								  message.Type.ToString("G"), message.Type.ToString("D"));
-				result = false;
-				break;
+				throw new RouterException(this.Name, $"invalid message type {message.Type}");
 			}
 
-			return result;
+			return true;
 		}
 	}
 }

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/ControlMessageRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/ControlMessageRouter.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Options;
 
 using Newtonsoft.Json;
 using Prometheus;
+
 using SensateIoT.Platform.Router.Common.Collections.Abstract;
 using SensateIoT.Platform.Router.Common.Routing.Abstract;
 using SensateIoT.Platform.Router.Common.Services.Processing;
@@ -19,6 +20,7 @@ using SensateIoT.Platform.Router.Common.Settings;
 using SensateIoT.Platform.Router.Contracts.DTO;
 using SensateIoT.Platform.Router.Data.Abstract;
 using SensateIoT.Platform.Router.Data.DTO;
+
 using ControlMessage = SensateIoT.Platform.Router.Data.DTO.ControlMessage;
 
 namespace SensateIoT.Platform.Router.Common.Routing.Routers
@@ -44,8 +46,7 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 			this.m_authService = auth;
 			this.m_settings = settings.Value;
 			this.m_logger = logger;
-			this.m_counter = Metrics.CreateCounter("router_controlmessage_messages_routed_total",
-														   "Total number of routed control messages.");
+			this.m_counter = Metrics.CreateCounter("router_controlmessage_messages_routed_total", "Total number of routed control messages.");
 		}
 
 		public bool Route(Sensor sensor, IPlatformMessage message, NetworkEvent networkEvent)
@@ -61,6 +62,7 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 		private bool ProcessMessage(Sensor sensor, ControlMessage message)
 		{
 			var data = JsonConvert.SerializeObject(message, Formatting.None);
+
 			message.Timestamp = DateTime.UtcNow;
 			message.Secret = sensor.SensorKey;
 			this.m_authService.SignControlMessage(message, data);

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/LiveDataRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/LiveDataRouter.cs
@@ -60,7 +60,6 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 			var routes = sensor.LiveDataRouting.ToList(); // Take a snapshot
 
 			foreach(var info in routes) {
-				this.m_logger.LogDebug("Routing message to live data client: {clientId}.", info.Target);
 				this.EnqueueTo(message, info);
 			}
 

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/LiveDataRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/LiveDataRouter.cs
@@ -47,9 +47,7 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 				return this.ProcessMessage(sensor, message, networkEvent);
 
 			default:
-				this.m_logger.LogError("Received invalid message type. Unable to route to live data service. " +
-									   "The received type is: {type}", message.Type);
-				throw new RouterException(nameof(LiveDataRouter), $"unable to route message of type {message.Type:G}");
+				throw new RouterException(this.Name, $"unable to route message of type {message.Type:G}");
 			}
 		}
 

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/LiveDataRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/LiveDataRouter.cs
@@ -71,13 +71,16 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 		{
 			switch(message.Type) {
 			case MessageType.ControlMessage:
+				this.m_logger.LogDebug("Queueing control message to {target}", target.Target);
 				this.m_internalQueue.EnqueueControlMessageToTarget(message, target);
 				break;
 			case MessageType.Message:
+				this.m_logger.LogDebug("Queueing message to {target}", target.Target);
 				this.m_internalQueue.EnqueueMessageToTarget(message, target);
 				break;
 
 			case MessageType.Measurement:
+				this.m_logger.LogDebug("Queueing measurement to {target}", target.Target);
 				this.m_internalQueue.EnqueueMeasurementToTarget(message, target);
 				break;
 			}

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/StorageRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/StorageRouter.cs
@@ -5,6 +5,7 @@
  * @email  michel@michelmegens.net
  */
 
+using Microsoft.Extensions.Logging;
 using Prometheus;
 using SensateIoT.Platform.Router.Common.Collections.Abstract;
 using SensateIoT.Platform.Router.Common.Routing.Abstract;
@@ -18,25 +19,42 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 	{
 		private readonly IRemoteStorageQueue m_storageQueue;
 		private readonly Counter m_counter;
+		private readonly ILogger<StorageRouter> m_logger;
 
 		public string Name => "Storage Router";
 
-		public StorageRouter(IRemoteStorageQueue queue)
+		public StorageRouter(IRemoteStorageQueue queue, ILogger<StorageRouter> logger)
 		{
 			this.m_storageQueue = queue;
+			this.m_logger = logger;
 			this.m_counter = Metrics.CreateCounter("router_storage_messages_routed_total",
 														   "Total number of routed storage messages.");
 		}
 
 		public bool Route(Sensor sensor, IPlatformMessage message, NetworkEvent networkEvent)
 		{
-			if(!sensor.StorageEnabled || message.Type == MessageType.ControlMessage) {
+			if(!this.ShouldStoreMessage(sensor, message)) {
 				return true;
 			}
 
 			this.m_counter.Inc();
 			this.m_storageQueue.Enqueue(message);
 			networkEvent.Actions.Add(NetworkEventType.MessageStorage);
+
+			return true;
+		}
+
+		private bool ShouldStoreMessage(Sensor sensor, IPlatformMessage message)
+		{
+			if(!sensor.StorageEnabled) {
+				this.m_logger.LogDebug("Skipping storage for {sensorId}: storage not enabled", sensor.ID.ToString());
+				return false;
+			}
+
+			if(message.Type == MessageType.ControlMessage) {
+				this.m_logger.LogDebug("Skipping storage for {sensorId}: message is of type Control Message", sensor.ID.ToString());
+				return false;
+			}
 
 			return true;
 		}

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
@@ -42,6 +42,7 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 			}
 
 			if(sensor.TriggerInformation == null || sensor.TriggerInformation.Count <= 0) {
+				this.m_logger.LogDebug($"Skipping the trigger router for sensor {sensor.ID}: no triggers available");
 				return true;
 			}
 

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
@@ -67,7 +67,7 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 
 		private bool MatchTrigger(IPlatformMessage message, NetworkEvent evt, SensorTrigger info, ref bool textTriggered, ref bool measurementTriggered)
 		{
-			if(!VerifySensorTrigger(message, info)) {
+			if(!this.VerifySensorTrigger(message, info)) {
 				return false;
 			}
 
@@ -81,12 +81,18 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 				this.EnqueueToTriggerService(message);
 			}
 
-			return textTriggered && measurementTriggered;
+			if(textTriggered && measurementTriggered) {
+				this.m_logger.LogDebug($"Skipping trigger for {message.SensorID}: already queued");
+				return true;
+			}
+
+			return false;
 		}
 
-		private static bool VerifySensorTrigger(IPlatformMessage message, SensorTrigger info)
+		private bool VerifySensorTrigger(IPlatformMessage message, SensorTrigger info)
 		{
 			if(!info.HasActions) {
+				this.m_logger.LogDebug($"Skipping message from sensor {message.SensorID}: no actions available");
 				return false;
 			}
 

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
@@ -10,8 +10,8 @@ using System.Linq;
 using Microsoft.Extensions.Logging;
 
 using Prometheus;
+
 using SensateIoT.Platform.Router.Common.Collections.Abstract;
-using SensateIoT.Platform.Router.Common.Exceptions;
 using SensateIoT.Platform.Router.Common.Routing.Abstract;
 using SensateIoT.Platform.Router.Contracts.DTO;
 using SensateIoT.Platform.Router.Data.Abstract;

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
@@ -103,11 +103,6 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 			case MessageType.Message:
 				this.m_internalRemote.EnqueueMessageToTriggerService(message);
 				break;
-
-			default:
-				this.m_logger.LogError("Received invalid message type. Unable to route message to trigger service. " +
-									   "The received type is: {type}", message.Type);
-				throw new RouterException(nameof(TriggerRouter), $"invalid message type: {message.Type:G}");
 			}
 		}
 

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
@@ -51,7 +51,6 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 
 		private void ProcessMessage(Sensor sensor, IPlatformMessage message, NetworkEvent evt)
 		{
-			this.m_counter.Inc();
 			var textTriggered = false;
 			var measurementTriggered = false;
 			var triggers = sensor.TriggerInformation.ToList(); // Snap shot
@@ -101,6 +100,8 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 
 		private void EnqueueToTriggerService(IPlatformMessage message)
 		{
+			this.m_counter.Inc();
+
 			switch(message.Type) {
 			case MessageType.Measurement:
 				this.m_internalRemote.EnqueueMeasurementToTriggerService(message);

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
@@ -31,8 +31,7 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 		{
 			this.m_internalRemote = queue;
 			this.m_logger = logger;
-			this.m_counter = Metrics.CreateCounter("router_trigger_messages_routed_total",
-														   "Total number of routed trigger messages.");
+			this.m_counter = Metrics.CreateCounter("router_trigger_messages_routed_total", "Total number of routed trigger messages.");
 		}
 
 		public bool Route(Sensor sensor, IPlatformMessage message, NetworkEvent networkEvent)

--- a/SensateIoT.Platform.Router.Contracts/DTO/NetworkEvent.proto
+++ b/SensateIoT.Platform.Router.Contracts/DTO/NetworkEvent.proto
@@ -16,6 +16,7 @@ enum NetworkEventType
 	MessageStorage = 1;
 	MessageTriggered = 2;
 	MessageLiveData = 3;
+	MessageDropped = 4;
 }
 
 enum NetworkMessageType

--- a/SensateIoT.Platform.Router.Service/SensateIoT.Platform.Router.Service.csproj
+++ b/SensateIoT.Platform.Router.Service/SensateIoT.Platform.Router.Service.csproj
@@ -23,8 +23,8 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.19.1" />
     <PackageReference Include="Grpc" Version="2.42.0" />
-    <PackageReference Include="Grpc.AspNetCore" Version="2.40.0" />
-    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.40.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.41.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.41.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="5.0.2" />
     <PackageReference Include="prometheus-net.AspNetCore.Grpc" Version="5.0.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />

--- a/SensateIoT.Platform.Router.Service/appsettings.Development.json
+++ b/SensateIoT.Platform.Router.Service/appsettings.Development.json
@@ -7,14 +7,14 @@
   "ApplicationId": "local", 
   "Database": {
     "SensateIoT": {
-      "ConnectionString": "User ID = postgres;Password=DefaultPassword;Server=localhost;Port=5432;Database=Sensate"
+      "ConnectionString": "User ID = postgres;Password=DefaultPassword;Server=localhost;Port=5432;Database=SensateIoT"
     },
     "Networking": {
       "ConnectionString": "User ID = postgres;Password=DefaultPassword;Server=localhost;Port=5432;Database=Networking"
     },
     "MongoDB": {
-      "ConnectionString": "mongodb://root:root@localhost:27017/Sensate?authSource=admin",
-      "DatabaseName": "Sensate"
+      "ConnectionString": "mongodb://root:root@localhost:27017/SensateIoT?authSource=admin",
+      "DatabaseName": "SensateIoT"
     }
   },
   "Mqtt": {


### PR DESCRIPTION
Improve internal routing in the Platform Router Service.

## Description
Various issues (actual bugs, or support questions) are hard to trace in the platform router. This PR improves logging in order to simplify this process. Furthermore, the process of dequeuing messages from the internal input queue and starting the routing process has been pulled in scope of the `CompositeRouter`. This change makes the composite router more autonomous. Timing (i.e. when the composite router is executed) of the routing process is still controlled by the `RoutingService`.

### Added
- Additional logging to various routers
- Input queue processing to the composite router

### Updated
- Project dependencies
- Confusing log lines
- Router metric logging
- Control flow of the composite router

### Removed
- Duplicate logging
- Code paths that cannot be executed

## Motivation and Context
Improve the troubleshooting process and the ability to monitor sub routers.

## How Has This Been Tested?
- [x] Unit tests
- [x] Manual tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

