### PR TITLE
Release 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Remote trigger queue implementation
+- Remote live data queue
+
+### Updated
+- Message processing by the composite router
+- Health monitoring service (use the new queue's)
+
+### Removed
+- The `InternalRemoteQueue` (refactored into the `RemoteLiveDataQueue`)
+
 ## [1.8.0] - 17-12-2021
 ### Added
 - Additional logging to various routers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 - Message processing by the composite router
 - Health monitoring service (use the new queue's)
+- Project dependencies
 
 ### Removed
 - The `InternalRemoteQueue` (refactored into the `RemoteLiveDataQueue`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.8.1] - 26-12-2021
 ### Added
 - Remote trigger queue implementation
 - Remote live data queue

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ The following metrics are collected from the routing service:
 
 [header1]: https://github.com/sensate-iot/platform-router/workflows/Docker/badge.svg "Docker Build"
 [header2]: https://github.com/sensate-iot/platform-router/workflows/Format%20check/badge.svg ".NET format"
-[header3]: https://img.shields.io/badge/version-v1.8.0-informational "Sensate IoT Router version"
+[header3]: https://img.shields.io/badge/version-v1.8.1-informational "Sensate IoT Router version"

--- a/README.md
+++ b/README.md
@@ -22,16 +22,18 @@ The message router needs various settings in order to function correctly:
   - MongoDB
   - PostgreSQL
 
-- Serilog configuration
 - Routing config:
   - Trigger topic
   - Storage topic
   - Network event topic
   - Actuator topic
   - Live data topic
+  - Publish interval
+  - Routing batch size
 
 - MQTT configuration
 - Metrics server
+- Serilog configuration
 
 ## Metrics
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The message router needs various settings in order to function correctly:
   - Routing batch size
 
 - MQTT configuration
+  - Internal MQTT broker
+  - Public MQTT broker
+
 - Metrics server
 - Serilog configuration
 

--- a/SensateIoT.Platform.Router.Common/Collections/Abstract/IRemoteLiveDataQueue.cs
+++ b/SensateIoT.Platform.Router.Common/Collections/Abstract/IRemoteLiveDataQueue.cs
@@ -7,24 +7,21 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using SensateIoT.Platform.Router.Data.Abstract;
 using SensateIoT.Platform.Router.Data.DTO;
 using SensateIoT.Platform.Router.Data.Models;
 
 namespace SensateIoT.Platform.Router.Common.Collections.Abstract
 {
-	public interface IInternalRemoteQueue
+	public interface IRemoteLiveDataQueue
 	{
-		public int LiveDataQueueLength { get; }
-		public int TriggerQueueLength { get; }
+		public int Count { get; }
 
-		void EnqueueMessageToTriggerService(IPlatformMessage message);
-		void EnqueueMeasurementToTriggerService(IPlatformMessage message);
 		void EnqueueMeasurementToTarget(IPlatformMessage message, RoutingTarget target);
 		void EnqueueMessageToTarget(IPlatformMessage message, RoutingTarget target);
 		void EnqueueControlMessageToTarget(IPlatformMessage message, RoutingTarget target);
 		Task FlushAsync();
-		Task FlushLiveDataAsync();
 
 		void SyncLiveDataHandlers(IEnumerable<LiveDataHandler> handlers);
 	}

--- a/SensateIoT.Platform.Router.Common/Collections/Abstract/IRemoteTriggerQueue.cs
+++ b/SensateIoT.Platform.Router.Common/Collections/Abstract/IRemoteTriggerQueue.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using SensateIoT.Platform.Router.Data.Abstract;
+
+namespace SensateIoT.Platform.Router.Common.Collections.Abstract
+{
+	public interface IRemoteTriggerQueue
+	{
+		public int Count { get; }
+
+		void EnqueueMessageToTriggerService(IPlatformMessage message);
+		void EnqueueMeasurementToTriggerService(IPlatformMessage message);
+		Task FlushAsync();
+	}
+}

--- a/SensateIoT.Platform.Router.Common/Collections/Remote/RemoteTriggerQueue.cs
+++ b/SensateIoT.Platform.Router.Common/Collections/Remote/RemoteTriggerQueue.cs
@@ -1,0 +1,133 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Options;
+
+using Google.Protobuf;
+using Prometheus;
+
+using SensateIoT.Platform.Router.Common.Collections.Abstract;
+using SensateIoT.Platform.Router.Common.Converters;
+using SensateIoT.Platform.Router.Common.Helpers;
+using SensateIoT.Platform.Router.Common.MQTT;
+using SensateIoT.Platform.Router.Common.Settings;
+using SensateIoT.Platform.Router.Contracts.DTO;
+using SensateIoT.Platform.Router.Data.Abstract;
+using SensateIoT.Platform.Router.Data.DTO;
+
+using Measurement = SensateIoT.Platform.Router.Data.DTO.Measurement;
+
+namespace SensateIoT.Platform.Router.Common.Collections.Remote
+{
+	public class RemoteTriggerQueue : IRemoteTriggerQueue
+	{
+		private SpinLockWrapper m_measurementLock;
+		private SpinLockWrapper m_messageLock;
+
+		private MeasurementData m_triggerMeasurements;
+		private TextMessageData m_triggerMessages;
+		private readonly string m_messageTriggerTopic;
+		private readonly string m_measurementTriggerTopic;
+		private readonly IInternalMqttClient m_client;
+		private readonly Gauge m_gaugeTriggerSerivce;
+
+		public int Count => this.GetTriggerQueueLength();
+
+		public RemoteTriggerQueue(IOptions<QueueSettings> options, IInternalMqttClient client)
+		{
+			this.m_gaugeTriggerSerivce = Metrics.CreateGauge("router_trigger_messages_queued", "Number of messages in the trigger queue.");
+
+			this.m_triggerMeasurements = new MeasurementData();
+			this.m_triggerMessages = new TextMessageData();
+			this.m_measurementLock = new SpinLockWrapper();
+			this.m_messageLock = new SpinLockWrapper();
+
+			this.m_client = client;
+			this.m_messageTriggerTopic = options.Value.TriggerQueueTemplate.Replace("$type", "messages");
+			this.m_measurementTriggerTopic = options.Value.TriggerQueueTemplate.Replace("$type", "measurements");
+		}
+
+		public void EnqueueMessageToTriggerService(IPlatformMessage message)
+		{
+			this.m_measurementLock.Lock();
+
+			try {
+				this.m_triggerMessages.Messages.Add(MessageProtobufConverter.Convert(message as Message));
+				this.m_gaugeTriggerSerivce.Inc();
+			} finally {
+				this.m_measurementLock.Unlock();
+			}
+		}
+
+		public void EnqueueMeasurementToTriggerService(IPlatformMessage message)
+		{
+			this.m_measurementLock.Lock();
+
+			try {
+				this.m_triggerMeasurements.Measurements.Add(MeasurementProtobufConverter.Convert(message as Measurement));
+				this.m_gaugeTriggerSerivce.Inc();
+			} finally {
+				this.m_measurementLock.Unlock();
+			}
+		}
+
+		public async Task FlushAsync()
+		{
+			MeasurementData measurements;
+			TextMessageData messages;
+
+			this.m_measurementLock.Lock();
+			this.m_messageLock.Lock();
+
+			try {
+				measurements = this.m_triggerMeasurements;
+				messages = this.m_triggerMessages;
+
+				this.m_gaugeTriggerSerivce.Set(0D);
+				this.m_triggerMeasurements = new MeasurementData();
+				this.m_triggerMessages = new TextMessageData();
+			} finally {
+				this.m_messageLock.Unlock();
+				this.m_measurementLock.Unlock();
+			}
+
+			await Task.WhenAll(
+				this.PublishData(this.m_messageTriggerTopic, messages),
+				this.PublishData(this.m_measurementTriggerTopic, measurements)
+			).ConfigureAwait(false);
+		}
+
+		private Task PublishData(string topic, IMessage messages)
+		{
+			var size = messages.CalculateSize();
+
+			if(size == 0) {
+				return Task.CompletedTask;
+			}
+
+			using var stream = new MemoryStream();
+			messages.WriteTo(stream);
+			var data = stream.ToArray().Compress();
+
+			return this.m_client.PublishOnAsync(topic, data, false);
+		}
+
+
+		private int GetTriggerQueueLength()
+		{
+			var size = 0;
+			this.m_measurementLock.Lock();
+			this.m_messageLock.Lock();
+
+			try {
+				size += this.m_triggerMeasurements.Measurements.Count;
+				size += this.m_triggerMessages.Messages.Count;
+			} finally {
+				this.m_messageLock.Unlock();
+				this.m_measurementLock.Unlock();
+			}
+
+			return size;
+		}
+	}
+}

--- a/SensateIoT.Platform.Router.Common/Init/RouterInitExtensions.cs
+++ b/SensateIoT.Platform.Router.Common/Init/RouterInitExtensions.cs
@@ -6,13 +6,17 @@
  */
 
 using System;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
 using SensateIoT.Platform.Router.Common.Caching.Abstract;
 using SensateIoT.Platform.Router.Common.Collections.Abstract;
 using SensateIoT.Platform.Router.Common.Routing;
 using SensateIoT.Platform.Router.Common.Routing.Abstract;
 using SensateIoT.Platform.Router.Common.Routing.Routers;
+using SensateIoT.Platform.Router.Common.Settings;
 using SensateIoT.Platform.Router.Data.Abstract;
 
 namespace SensateIoT.Platform.Router.Common.Init
@@ -33,7 +37,8 @@ namespace SensateIoT.Platform.Router.Common.Init
 				var queue = provider.GetRequiredService<IRemoteNetworkEventQueue>();
 				var inputQueue = provider.GetRequiredService<IQueue<IPlatformMessage>>();
 				var logger = provider.GetRequiredService<ILogger<CompositeRouter>>();
-				var router = new CompositeRouter(cache, inputQueue, queue, logger) as IMessageRouter;
+				var options = provider.GetRequiredService<IOptions<RoutingQueueSettings>>();
+				var router = new CompositeRouter(cache, inputQueue, queue, options, logger) as IMessageRouter;
 
 				AddRouters(router, provider);
 

--- a/SensateIoT.Platform.Router.Common/Routing/Abstract/IMessageRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Abstract/IMessageRouter.cs
@@ -6,12 +6,13 @@
  */
 
 using System;
+using System.Threading;
 
 namespace SensateIoT.Platform.Router.Common.Routing.Abstract
 {
 	public interface IMessageRouter : IDisposable
 	{
 		void AddRouter(IRouter router);
-		bool TryRoute();
+		bool TryRoute(CancellationToken token = default);
 	}
 }

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/ControlMessageRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/ControlMessageRouter.cs
@@ -30,7 +30,7 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 	{
 		private readonly IPublicRemoteQueue m_publicQueue;
 		private readonly ILogger<ControlMessageRouter> m_logger;
-		private readonly RoutingPublishSettings m_settings;
+		private readonly RoutingQueueSettings m_settings;
 		private readonly IAuthorizationService m_authService;
 		private readonly Counter m_counter;
 
@@ -39,7 +39,7 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 		public string Name => "Control Message Router";
 
 		public ControlMessageRouter(IPublicRemoteQueue remote,
-									IOptions<RoutingPublishSettings> settings,
+									IOptions<RoutingQueueSettings> settings,
 									ILogger<ControlMessageRouter> logger,
 									IAuthorizationService auth)
 		{

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/LiveDataRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/LiveDataRouter.cs
@@ -9,6 +9,7 @@ using System.Linq;
 
 using Microsoft.Extensions.Logging;
 using Prometheus;
+
 using SensateIoT.Platform.Router.Common.Collections.Abstract;
 using SensateIoT.Platform.Router.Common.Exceptions;
 using SensateIoT.Platform.Router.Common.Routing.Abstract;
@@ -21,12 +22,12 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 	public class LiveDataRouter : IRouter
 	{
 		private readonly ILogger<LiveDataRouter> m_logger;
-		private readonly IInternalRemoteQueue m_internalQueue;
+		private readonly IRemoteLiveDataQueue m_internalQueue;
 		private readonly Counter m_liveDataCounter;
 
 		public string Name => "Live Data Router";
 
-		public LiveDataRouter(ILogger<LiveDataRouter> logger, IInternalRemoteQueue queue)
+		public LiveDataRouter(ILogger<LiveDataRouter> logger, IRemoteLiveDataQueue queue)
 		{
 			this.m_internalQueue = queue;
 			this.m_logger = logger;

--- a/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
+++ b/SensateIoT.Platform.Router.Common/Routing/Routers/TriggerRouter.cs
@@ -21,13 +21,13 @@ namespace SensateIoT.Platform.Router.Common.Routing.Routers
 {
 	public class TriggerRouter : IRouter
 	{
-		private readonly IInternalRemoteQueue m_internalRemote;
+		private readonly IRemoteTriggerQueue m_internalRemote;
 		private readonly ILogger<TriggerRouter> m_logger;
 		private readonly Counter m_counter;
 
 		public string Name => "Trigger Router";
 
-		public TriggerRouter(IInternalRemoteQueue queue, ILogger<TriggerRouter> logger)
+		public TriggerRouter(IRemoteTriggerQueue queue, ILogger<TriggerRouter> logger)
 		{
 			this.m_internalRemote = queue;
 			this.m_logger = logger;

--- a/SensateIoT.Platform.Router.Common/Services/Data/DataReloadService.cs
+++ b/SensateIoT.Platform.Router.Common/Services/Data/DataReloadService.cs
@@ -26,20 +26,20 @@ namespace SensateIoT.Platform.Router.Common.Services.Data
 	public class DataReloadService : TimedBackgroundService
 	{
 		private readonly IServiceProvider m_provider;
-		private readonly IInternalRemoteQueue m_queue;
+		private readonly IRemoteLiveDataQueue m_queue;
 		private readonly IRoutingCache m_cache;
 		private readonly ILogger<DataReloadService> m_logger;
 		private bool m_loaded;
 		private readonly DataReloadSettings m_settings;
 
 		public DataReloadService(IServiceProvider provider,
-											IInternalRemoteQueue internalRemote,
+											IRemoteLiveDataQueue liveDataQueue,
 											IRoutingCache cache,
 											IOptions<DataReloadSettings> settings,
 											ILogger<DataReloadService> logger) : base(settings.Value.StartDelay, settings.Value.DataReloadInterval, logger)
 		{
 			this.m_provider = provider;
-			this.m_queue = internalRemote;
+			this.m_queue = liveDataQueue;
 			this.m_logger = logger;
 			this.m_cache = cache;
 			this.m_loaded = false;

--- a/SensateIoT.Platform.Router.Common/Services/Metrics/HealthMonitoringService.cs
+++ b/SensateIoT.Platform.Router.Common/Services/Metrics/HealthMonitoringService.cs
@@ -12,27 +12,30 @@ namespace SensateIoT.Platform.Router.Common.Services.Metrics
 {
 	public class HealthMonitoringService : IHealthMonitoringService
 	{
-		private readonly IInternalRemoteQueue m_internalRemoteQueues;
+		private readonly IRemoteLiveDataQueue m_liveDataQueues;
 		private readonly IPublicRemoteQueue m_publicQueue;
 		private readonly IQueue<IPlatformMessage> m_inputQueue;
 		private readonly HealthCheckSettings m_settings;
 		private readonly IPublicMqttClient m_publicMqttClient;
 		private readonly IInternalMqttClient m_internalMqttClient;
+		private readonly IRemoteTriggerQueue m_triggerQueue;
 
 		public bool IsHealthy => this.GetHealthStatus();
 
 		public HealthMonitoringService(IQueue<IPlatformMessage> inputQueue,
-									   IInternalRemoteQueue @internal,
+									   IRemoteTriggerQueue triggerQueue,
+									   IRemoteLiveDataQueue @internal,
 									   IPublicRemoteQueue @public,
 									   IPublicMqttClient publicClient,
 									   IInternalMqttClient internalClient,
 									   IOptions<HealthCheckSettings> settings)
 		{
-			this.m_internalRemoteQueues = @internal;
+			this.m_liveDataQueues = @internal;
 			this.m_publicQueue = @public;
 			this.m_inputQueue = inputQueue;
 			this.m_internalMqttClient = internalClient;
 			this.m_publicMqttClient = publicClient;
+			this.m_triggerQueue = triggerQueue;
 			this.m_settings = settings.Value;
 		}
 
@@ -97,13 +100,13 @@ namespace SensateIoT.Platform.Router.Common.Services.Metrics
 		private bool CheckLiveDataQueues()
 		{
 			var limit = this.m_settings.LiveDataServiceQueueLimit ?? this.m_settings.DefaultQueueLimit;
-			return this.m_internalRemoteQueues.LiveDataQueueLength <= limit;
+			return this.m_liveDataQueues.Count <= limit;
 		}
 
 		private bool CheckTriggerQueues()
 		{
 			var limit = this.m_settings.TriggerServiceQueueLimit ?? this.m_settings.DefaultQueueLimit;
-			return this.m_internalRemoteQueues.TriggerQueueLength <= limit;
+			return this.m_triggerQueue.Count <= limit;
 		}
 	}
 }

--- a/SensateIoT.Platform.Router.Common/Services/Processing/ActuatorPublishService.cs
+++ b/SensateIoT.Platform.Router.Common/Services/Processing/ActuatorPublishService.cs
@@ -22,7 +22,7 @@ namespace SensateIoT.Platform.Router.Common.Services.Processing
 		private readonly IPublicRemoteQueue m_remote;
 
 		public ActuatorPublishService(IPublicRemoteQueue remote,
-									IOptions<RoutingPublishSettings> options,
+									IOptions<RoutingQueueSettings> options,
 									ILogger<ActuatorPublishService> logger) : base(TimeSpan.FromSeconds(5), options.Value.PublicInterval, logger)
 		{
 			this.m_remote = remote;

--- a/SensateIoT.Platform.Router.Common/Services/Processing/RoutingPublishService.cs
+++ b/SensateIoT.Platform.Router.Common/Services/Processing/RoutingPublishService.cs
@@ -8,8 +8,10 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+
 using SensateIoT.Platform.Router.Common.Collections.Abstract;
 using SensateIoT.Platform.Router.Common.Services.Background;
 using SensateIoT.Platform.Router.Common.Settings;
@@ -18,25 +20,28 @@ namespace SensateIoT.Platform.Router.Common.Services.Processing
 {
 	public class RoutingPublishService : TimedBackgroundService
 	{
-		private readonly IInternalRemoteQueue m_internalRemote;
+		private readonly IRemoteLiveDataQueue m_liveDataQueue;
+		private readonly IRemoteTriggerQueue m_triggerQueue;
 		private readonly IRemoteStorageQueue m_remoteStorageQueue;
 		private readonly IRemoteNetworkEventQueue m_eventQueue;
 
-		public RoutingPublishService(IInternalRemoteQueue internalRemote,
+		public RoutingPublishService(IRemoteLiveDataQueue liveDataQueue,
+									 IRemoteTriggerQueue triggerQueue,
 									 IRemoteStorageQueue remoteStorage,
 									 IRemoteNetworkEventQueue remoteEvents,
-									 IOptions<RoutingPublishSettings> options,
+									 IOptions<RoutingQueueSettings> options,
 									 ILogger<RoutingPublishService> logger) : base(TimeSpan.FromSeconds(5), options.Value.InternalInterval, logger)
 		{
-			this.m_internalRemote = internalRemote;
+			this.m_liveDataQueue = liveDataQueue;
 			this.m_remoteStorageQueue = remoteStorage;
 			this.m_eventQueue = remoteEvents;
+			this.m_triggerQueue = triggerQueue;
 		}
 
 		protected override async Task ExecuteAsync(CancellationToken token)
 		{
-			await Task.WhenAll(this.m_internalRemote.FlushAsync(),
-							   this.m_internalRemote.FlushLiveDataAsync(),
+			await Task.WhenAll(this.m_liveDataQueue.FlushAsync(),
+							   this.m_triggerQueue.FlushAsync(),
 							   this.m_eventQueue.FlushEventsAsync(),
 							   this.m_remoteStorageQueue.FlushMessagesAsync()).ConfigureAwait(false);
 		}

--- a/SensateIoT.Platform.Router.Common/Settings/RoutingQueueSettings.cs
+++ b/SensateIoT.Platform.Router.Common/Settings/RoutingQueueSettings.cs
@@ -9,10 +9,11 @@ using System;
 
 namespace SensateIoT.Platform.Router.Common.Settings
 {
-	public class RoutingPublishSettings
+	public class RoutingQueueSettings
 	{
 		public TimeSpan PublicInterval { get; set; }
 		public TimeSpan InternalInterval { get; set; }
+		public int? DequeueBatchSize { get; set; }
 		public string ActuatorTopicFormat { get; set; }
 	}
 }

--- a/SensateIoT.Platform.Router.DataAccess/SensateIoT.Platform.Router.DataAccess.csproj
+++ b/SensateIoT.Platform.Router.DataAccess/SensateIoT.Platform.Router.DataAccess.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.14.1" />
-    <PackageReference Include="Npgsql" Version="6.0.1" />
+    <PackageReference Include="Npgsql" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SensateIoT.Platform.Router.Service/Init/RoutingInitExtensions.cs
+++ b/SensateIoT.Platform.Router.Service/Init/RoutingInitExtensions.cs
@@ -34,10 +34,11 @@ namespace SensateIoT.Platform.Router.Service.Init
 			services.AddSingleton<IRoutingCache, RoutingCache>();
 			services.AddSingleton<IHostedService, RoutingService>();
 
-			services.Configure<RoutingPublishSettings>(s => {
+			services.Configure<RoutingQueueSettings>(s => {
 				s.InternalInterval = TimeSpan.FromMilliseconds(configuration.GetValue<int>("Routing:InternalPublishInterval"));
 				s.PublicInterval = TimeSpan.FromMilliseconds(configuration.GetValue<int>("Routing:PublicPublishInterval"));
 				s.ActuatorTopicFormat = configuration.GetValue<string>("Routing:ActuatorTopicFormat");
+				s.DequeueBatchSize = configuration.GetValue<int>("Routing:DequeueBatchSize");
 			});
 		}
 
@@ -46,7 +47,8 @@ namespace SensateIoT.Platform.Router.Service.Init
 			// Routing queues
 			services.AddSingleton<IQueue<IPlatformMessage>, MessageQueue>();
 			services.AddSingleton<IRemoteNetworkEventQueue, RemoteNetworkEventQueue>();
-			services.AddSingleton<IInternalRemoteQueue, InternalMqttQueue>();
+			services.AddSingleton<IRemoteLiveDataQueue, RemoteLiveDataQueue>();
+			services.AddSingleton<IRemoteTriggerQueue, RemoteTriggerQueue>();
 			services.AddSingleton<IPublicRemoteQueue, PublicMqttQueue>();
 			services.AddSingleton<IRemoteStorageQueue, RemoteStorageQueue>();
 

--- a/SensateIoT.Platform.Router.Service/SensateIoT.Platform.Router.Service.csproj
+++ b/SensateIoT.Platform.Router.Service/SensateIoT.Platform.Router.Service.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
-    <Version>1.8.0</Version>
-    <AssemblyVersion>1.8.0.0</AssemblyVersion>
-    <FileVersion>1.8.0.0</FileVersion>
+    <Version>1.8.1</Version>
+    <AssemblyVersion>1.8.1.0</AssemblyVersion>
+    <FileVersion>1.8.1.0</FileVersion>
     <Copyright>Sensate IoT</Copyright>
     <Company>Sensate IoT</Company>
     <Authors>Sensate IoT</Authors>

--- a/SensateIoT.Platform.Router.Service/appsettings.Development.json
+++ b/SensateIoT.Platform.Router.Service/appsettings.Development.json
@@ -66,7 +66,8 @@
     "LiveDataReloadInterval": 90
   },
   "Routing": {
-    "InternalPublishInterval": 350,
-    "PublicPublishInterval": 350
+    "DequeueBatchSize": 1000, 
+    "InternalPublishInterval": 1000,
+    "PublicPublishInterval": 1000 
   }
 }

--- a/SensateIoT.Platform.Router.Service/appsettings.example.json
+++ b/SensateIoT.Platform.Router.Service/appsettings.example.json
@@ -33,16 +33,19 @@
   },
   "Database": {
     "SensateIoT": {
-      "ConnectionString": "User ID = postgres;Password=DefaultPassword;Server=localhost;Port=5432;Database=Sensate"
+      "ConnectionString": "User ID = postgres;Password=DefaultPassword;Server=localhost;Port=5432;Database=SensateIoT"
     },
     "Networking": {
-      "ConnectionString": "User ID = postgres;Password=DefaultPassword;Server=localhost;Port=5432;Database=Sensate"
+      "ConnectionString": "User ID = postgres;Password=DefaultPassword;Server=localhost;Port=5432;Database=Networking"
     },
     "MongoDB": {
-      "DatabaseName": "Sensate",
-      "ConnectionString": "mongodb://root:root@localhost:27017/Sensate?authSource=admin",
+      "DatabaseName": "SensateIoT",
+      "ConnectionString": "mongodb://root:root@localhost:27017/SensateIoT?authSource=admin",
       "MaxConnections": 300
     }
+  },
+  "HealthChecks": {
+    "DefaultQueueLimit": 500
   },
   "Mqtt": {
     "InternalBroker": {
@@ -69,6 +72,7 @@
     "Capacity": 30000
   },
   "Routing": {
+    "DequeueBatchSize": 1000, 
     "TriggerTopic": "sensateiot/triggers/internal/$type/bulk",
     "LiveDataTopic": "sensateiot/live/internal/$type/$target/bulk",
     "ActuatorTopicFormat": "sensateiot/actuators/$id",

--- a/SensateIoT.Platform.Router.Tests/Collections/MqttQueueTests.cs
+++ b/SensateIoT.Platform.Router.Tests/Collections/MqttQueueTests.cs
@@ -50,7 +50,7 @@ namespace SensateIoT.Platform.Router.Tests.Collections
 				Target = "Remote"
 			});
 
-			queue.FlushLiveDataAsync();
+			queue.FlushAsync();
 			Assert.AreEqual(1, ClientStub.GetPublishCount("sensateiot/internal/messages/Local/bulk"));
 			Assert.AreEqual(1, ClientStub.GetPublishCount("sensateiot/internal/messages/Remote/bulk"));
 		}
@@ -78,13 +78,13 @@ namespace SensateIoT.Platform.Router.Tests.Collections
 				Data = new Dictionary<string, DataPoint>()
 			}, new RoutingTarget() { Target = "Local" });
 
-			queue.FlushLiveDataAsync();
+			queue.FlushAsync();
 			Assert.AreEqual(1, ClientStub.GetPublishCount("sensateiot/internal/measurements/Local/bulk"));
 		}
 
-		internal static MqttClientStub ClientStub = new MqttClientStub();
+		private static readonly MqttClientStub ClientStub = new();
 
-		internal static IInternalRemoteQueue BuildRemoteQueue()
+		private static IRemoteLiveDataQueue BuildRemoteQueue()
 		{
 			var settings = new QueueSettings {
 				LiveDataQueueTemplate = "sensateiot/internal/$type/$target/bulk",
@@ -92,7 +92,7 @@ namespace SensateIoT.Platform.Router.Tests.Collections
 			};
 
 
-			var remote = new InternalMqttQueue(new OptionsWrapper<QueueSettings>(settings), ClientStub);
+			var remote = new RemoteLiveDataQueue(new OptionsWrapper<QueueSettings>(settings), ClientStub);
 
 			remote.SyncLiveDataHandlers(new[] {
 				new LiveDataHandler {

--- a/SensateIoT.Platform.Router.Tests/Routing/AuthorizationRouterTests.cs
+++ b/SensateIoT.Platform.Router.Tests/Routing/AuthorizationRouterTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using MongoDB.Bson;
@@ -13,6 +14,7 @@ using SensateIoT.Platform.Router.Common.Collections.Local;
 using SensateIoT.Platform.Router.Common.Routing;
 using SensateIoT.Platform.Router.Common.Routing.Abstract;
 using SensateIoT.Platform.Router.Common.Routing.Routers;
+using SensateIoT.Platform.Router.Common.Settings;
 using SensateIoT.Platform.Router.Data.Abstract;
 using SensateIoT.Platform.Router.Data.DTO;
 
@@ -155,13 +157,14 @@ namespace SensateIoT.Platform.Router.Tests.Routing
 		{
 			var logger = new Mock<ILogger<CompositeRouter>>();
 			var queue = new Mock<IRemoteNetworkEventQueue>();
+			var options = Options.Create(new RoutingQueueSettings());
 
-			return new CompositeRouter(CreateRoutingCache(sensor, account, key), inputQueue, queue.Object, logger.Object);
+			return new CompositeRouter(CreateRoutingCache(sensor, account, key), inputQueue, queue.Object, options, logger.Object);
 		}
 
 		private static AuthorizationRouter CreateAuthorizationRouter(Action measurementCallback, Action messageCallback, Sensor s, Account a, ApiKey key)
 		{
-			var queue = new Mock<IInternalRemoteQueue>();
+			var queue = new Mock<IRemoteTriggerQueue>();
 			var logger = new Mock<ILogger<AuthorizationRouter>>();
 
 			queue.Setup(x => x.EnqueueMeasurementToTriggerService(It.IsAny<IPlatformMessage>()))

--- a/SensateIoT.Platform.Router.Tests/Routing/TriggerRouterTests.cs
+++ b/SensateIoT.Platform.Router.Tests/Routing/TriggerRouterTests.cs
@@ -143,7 +143,7 @@ namespace SensateIoT.Platform.Router.Tests.Routing
 
 		private static TriggerRouter CreateTriggerRouter(Action measurementCallback, Action messageCallback)
 		{
-			var queue = new Mock<IInternalRemoteQueue>();
+			var queue = new Mock<IRemoteTriggerQueue>();
 			var logger = new Mock<ILogger<TriggerRouter>>();
 
 			queue.Setup(x => x.EnqueueMeasurementToTriggerService(It.IsAny<IPlatformMessage>()))


### PR DESCRIPTION
Merge changes for the Sensate IoT Platform Router 1.8.1

## Description
Changes for version 1.8.1 of the Platform Router:

### Added
- Remote trigger queue implementation
- Remote live data queue

### Updated
- Message processing by the composite router
- Health monitoring service (use the new queue's)
- Project dependencies

### Removed
- The `InternalRemoteQueue` (refactored into the `RemoteLiveDataQueue`)

## How Has This Been Tested?
- Manual testing & verification
- Unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements (non-breaking change which improves the code quality or performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

